### PR TITLE
Use Node 14 base image & ensure OpenJDK 11 is installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM node:12-buster
+# Fermium = Node 14 LTS
+FROM node:fermium
 
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
 RUN wget -q -O - https://download.docker.com/linux/debian/gpg | apt-key add -
 RUN echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
+RUN echo "deb http://ftp.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/stretch-backports.list
 
 RUN apt update -yqqq
 RUN apt upgrade -y


### PR DESCRIPTION
Title says it all.

```bash
root@aeae2a5ac804:/# node -v
v14.18.2
root@aeae2a5ac804:/# npm -v
6.14.15
root@aeae2a5ac804:/# java -version
openjdk version "11.0.6" 2020-01-14
OpenJDK Runtime Environment (build 11.0.6+10-post-Debian-1bpo91)
OpenJDK 64-Bit Server VM (build 11.0.6+10-post-Debian-1bpo91, mixed mode, sharing)
root@aeae2a5ac804:/# sencha help
Sencha Cmd v7.3.0.19
```


Please review.