### PR TITLE
Use Node 16 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Fermium = Node 14 LTS
-FROM node:fermium
+# Gallium = Node 16 LTS
+FROM node:gallium
 
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
 RUN wget -q -O - https://download.docker.com/linux/debian/gpg | apt-key add -


### PR DESCRIPTION
Use a newer node.

At the time of building this results in

```
node -v && npm -v && java -version && sencha help
v16.13.1
8.1.2
openjdk version "11.0.12" 2021-07-20
OpenJDK Runtime Environment (build 11.0.12+7-post-Debian-2deb10u1)
OpenJDK 64-Bit Server VM (build 11.0.12+7-post-Debian-2deb10u1, mixed mode, sharing)
Sencha Cmd v7.3.0.19
[…]
```

Please review.